### PR TITLE
Add initial commit for qcom-metadata.dts for multi DT support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+# Makefile for compiling qcom-metadata.dts to qcom-metadata.dtb
+#
+DTC      ?= dtc
+SRC      := qcom-metadata.dts
+OUT      := qcom-metadata.dtb
+O        ?= .
+
+OUTFILE  := $(O)/$(OUT)
+
+all: $(OUTFILE)
+
+$(OUTFILE): $(SRC)
+	@mkdir -p $(O)
+	@$(DTC) -I dts -O dtb -o $(OUTFILE) $(SRC)
+	@echo "DTC $(OUTFILE)"
+
+clean:
+	@rm -f $(OUTFILE)
+	@echo "CLEAN $(OUTFILE)"

--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BSD-3-Clause-clear
+/*
+ * qcom metadata device tree source
+ *
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ *
+ */
+
+/dts-v1/;
+
+/ {
+	description = "Image with compressed metadata blob";
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	soc {
+		qcm6490 {
+			msm-id = <0x000001f1 0x10>;
+		};
+
+		qcs615 {
+			msm-id = <0x000002a8 0x10>;
+		};
+
+		qcs615v1.1 {
+			msm-id = <0x000002a8 0x11>;
+		};
+
+		qcs6490 {
+			msm-id = <0x000001f2 0x10>;
+		};
+
+		qcs8275 {
+			msm-id = <0x000002a3 0x10>;
+		};
+
+		qcs8300 {
+			msm-id = <0x000002a2 0x10>;
+		};
+
+		qcs9075 {
+			msm-id = <0x000002a4 0x10>;
+		};
+
+		qcs9075v2 {
+			msm-id = <0x000002a4 0x20>;
+		};
+
+		qcs9100 {
+			msm-id = <0x0000029b 0x10>;
+		};
+
+		qcs9100v2 {
+			msm-id = <0x0000029b 0x20>;
+		};
+	};
+
+	soc-sku {
+		sku0 {
+			msm-id = <0x00030000>;
+		};
+	};
+
+	board {
+		adp {
+			board-id = <0x00000019>;
+		};
+
+		atp {
+			board-id = <0x00000021>;
+		};
+
+		cdp {
+			board-id = <0x00000001>;
+		};
+
+		idp {
+			board-id = <0x00000022>;
+		};
+
+		iot {
+			board-id = <0x00000020>;
+		};
+
+		mtp {
+			board-id = <0x00000008>;
+		};
+
+		qam {
+			board-id = <0x00000025>;
+		};
+
+		qamr2 {
+			board-id = <0x00002025>;
+		};
+
+		qrd {
+			board-id = <0x0000000b>;
+		};
+	};
+
+	board-subtype-peripheral-subtype {
+		subtype0 {
+			board-subtype  = <0x00000000>;
+		};
+
+		subtype1 {
+			board-subtype  = <0x00000001>;
+		};
+
+		subtype2 {
+			board-subtype  = <0x00000002>;
+		};
+
+		subtype3 {
+			board-subtype  = <0x00000003>;
+		};
+
+		subtype4 {
+			board-subtype  = <0x00000004>;
+		};
+
+		subtype5 {
+			board-subtype  = <0x00000005>;
+		};
+
+		subtype6 {
+			board-subtype  = <0x00000006>;
+		};
+
+		subtype7 {
+			board-subtype  = <0x00000007>;
+		};
+
+		subtype8 {
+			board-subtype  = <0x00000008>;
+		};
+
+		subtype9 {
+			board-subtype  = <0x00000009>;
+		};
+		
+		subtype10 {
+			board-subtype  = <0x0000000a>;
+		};
+	};
+
+
+	board-subtype-storage-type {
+		emmc {
+			board-subtype = <0x00001000>;
+		};
+
+		nand {
+			board-subtype = <0x00002000>;
+		};
+
+		ufs {
+			board-subtype = <0x00000000>;
+		};
+	};
+
+	board-subtype-memory-size {
+		256MB {
+			board-subtype = <0x00000100>;
+		};
+
+		512MB {
+			board-subtype = <0x00000200>;
+		};
+
+		1GB {
+			board-subtype = <0x00000300>;
+		};
+
+		2GB {
+			board-subtype = <0x00000400>;
+		};
+
+		3GB {
+			board-subtype = <0x00000500>;
+		};
+
+		4GB {
+			board-subtype = <0x00000600>;
+		};
+
+		4GB+ {
+			board-subtype = <0x00000000>;
+		};
+	};
+
+	softsku {
+		softsku0 {
+			softsku-id = <0x0>;
+		};
+
+		softsku1 {
+			softsku-id = <0x1>;
+		};
+	};
+
+	oem {
+
+	};
+};


### PR DESCRIPTION
Introduce qcom-metadata.dts to provide SoC and board details for multi DT support using the FIT approach. This enables dynamic DT selection during boot for supported platforms. Adding Makefile to compile it.