### PR TITLE
Add ITS file for the Qualcomm FIT image

### DIFF
--- a/qcom-fitimage.its
+++ b/qcom-fitimage.its
@@ -69,7 +69,7 @@
 			fdt = "fdt-lemans-evk.dtb";
 		};
 		conf-6 {
-			compatible = "qcom,qcs9100-adp";
+			compatible = "qcom,qcs9100-qam";
 			fdt = "fdt-qcs9100-ride.dtb";
 		};
 		conf-7 {


### PR DESCRIPTION
Add the Image Tree Source (ITS) file for Qualcomm FIT image having images  and configuration information for the DTBs/DTBOs.