### PR TITLE
Update qcom-metadata.dts

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -10,8 +10,6 @@
 
 / {
 	description = "Image with compressed metadata blob";
-	#address-cells = <2>;
-	#size-cells = <2>;
 
 	soc {
 		qcm6490 {


### PR DESCRIPTION
Remove the address-cells and size-cells properties since in present case 32-bit cells are sufficient to represent a full address and size.