### PR TITLE
Update qcom-fitimage.its

### DIFF
--- a/qcom-fitimage.its
+++ b/qcom-fitimage.its
@@ -69,7 +69,7 @@
 			fdt = "fdt-lemans-evk.dtb";
 		};
 		conf-6 {
-			compatible = "qcom,qcs9100-adp";
+			compatible = "qcom,qcs9100-qam";
 			fdt = "fdt-qcs9100-ride.dtb";
 		};
 		conf-7 {


### PR DESCRIPTION
Update the compatible string for qcs9100-ride platform.