### PR TITLE
Add the FIT ITS file for the kernel qcom-next branch

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -1,0 +1,148 @@
+/dts-v1/;
+
+/ {
+	description = "Qualcomm FIT Image for DTBs";
+
+	images {
+		fdt-qcom-metadata.dtb {
+			description = "metadata for multi-DTB selection";
+			data = /incbin/("./qcom-metadata.dtb");
+			type = "qcom_metadata";
+		};
+		fdt-qcm6490-idp.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcm6490-idp.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs6490-rb3gen2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs6490-rb3gen2-vision-mezzanine.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-vision-mezzanine.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtb");
+			type = "flat_dt";
+		};
+		fdt-lemans-evk.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-evk.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs9100-ride.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs9100-ride.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs9100-ride-r3.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs9100-ride-r3.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs8300-ride.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs8300-ride.dtb");
+			type = "flat_dt";
+		};
+		fdt-monaco-evk.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-evk.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs615-ride.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs615-ride.dtb");
+			type = "flat_dt";
+		};
+		fdt-sa8775p-ride.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/sa8775p-ride.dtb");
+			type = "flat_dt";
+		};
+		fdt-sa8775p-ride-r3.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/sa8775p-ride-r3.dtb");
+			type = "flat_dt";
+		};
+		fdt-hamoa-iot-evk.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-iot-evk.dtb");
+			type = "flat_dt";
+		};
+	};
+
+	configurations {
+		conf-1 {
+			compatible = "qcom,qcm6490-idp";
+			fdt = "fdt-qcm6490-idp.dtb";
+		};
+		conf-2 {
+			compatible = "qcom,qcs6490-iot";
+			fdt = "fdt-qcs6490-rb3gen2.dtb";
+		};
+		conf-3 {
+			compatible = "qcom,qcs6490-iot-subtype2";
+			fdt = "fdt-qcs6490-rb3gen2-vision-mezzanine.dtb";
+		};
+		conf-4 {
+			compatible = "qcom,qcs6490-iot-subtype9";
+			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb";
+		};
+		conf-5 {
+			compatible = "qcom,qcs9075-iot";
+			fdt = "fdt-lemans-evk.dtb";
+		};
+		conf-6 {
+			compatible = "qcom,qcs9075v2-iot";
+			fdt = "fdt-lemans-evk.dtb";
+		};
+		conf-7 {
+			compatible = "qcom,qcs9100-qam";
+			fdt = "fdt-qcs9100-ride.dtb";
+		};
+		conf-8 {
+			compatible = "qcom,qcs9100v2-qam";
+			fdt = "fdt-qcs9100-ride.dtb";
+		};
+		conf-9 {
+			compatible = "qcom,qcs9100-qamr2";
+			fdt = "fdt-qcs9100-ride-r3.dtb";
+		};
+		conf-10 {
+			compatible = "qcom,qcs9100v2-qamr2";
+			fdt = "fdt-qcs9100-ride-r3.dtb";
+		};
+		conf-11 {
+			compatible = "qcom,qcs8300-adp";
+			fdt = "fdt-qcs8300-ride.dtb";
+		};
+		conf-12 {
+			compatible = "qcom,qcs8275-iot";
+			fdt = "fdt-monaco-evk.dtb";
+		};
+		conf-13 {
+			compatible = "qcom,qcs615-adp";
+			fdt = "fdt-qcs615-ride.dtb";
+		};
+		conf-14 {
+			compatible = "qcom,qcs615v1.1-adp";
+			fdt = "fdt-qcs615-ride.dtb";
+		};
+		conf-15 {
+			compatible = "qcom,sa8775p-qam";
+			fdt = "fdt-sa8775p-ride.dtb";
+		};
+		conf-16 {
+			compatible = "qcom,sa8775pv2-qam";
+			fdt = "fdt-sa8775p-ride.dtb";
+		};
+		conf-17 {
+			compatible = "qcom,sa8775p-qamr2";
+			fdt = "fdt-sa8775p-ride-r3.dtb";
+		};
+		conf-18 {
+			compatible = "qcom,sa8775pv2-qamr2";
+			fdt = "fdt-sa8775p-ride-r3.dtb";
+		};
+		conf-19 {
+			compatible = "qcom,hamoa-evk";
+			fdt = "fdt-hamoa-iot-evk.dtb";
+		};
+		conf-20 {
+			compatible = "qcom,hamoav2.1-evk";
+			fdt = "fdt-hamoa-iot-evk.dtb";
+		};
+	};
+};


### PR DESCRIPTION
Add the FIT image ITS file qcom-next-fitimage.its to meet the devicetree overlay requirements for the kernel qcom-next branch: -
https://github.com/qualcomm-linux/kernel/tree/qcom-next/arch/arm64/boot/dts/qcom