### PR TITLE
qcom-platforms: Add list of supported platforms

### DIFF
--- a/qcom-platforms.md
+++ b/qcom-platforms.md
@@ -1,0 +1,18 @@
+## Qualcomm Linux Supported Platforms
+
+| Platform | SoC Details | Board Details | DTB / DTBO File(s) |
+|----------|-------------|---------------|--------------------|
+| QCM6490 IDP | QCM6490 | IDP | qcm6490-idp.dtb |
+| QCS6490 IOT RB3 Gen2 | QCS6490 | RB3 Gen2 | qcs6490-rb3gen2.dtb |
+| QCS6490 IOT – Vision kit | QCS6490 | RB3 Gen2 + Vision Mezzanine | qcs6490-rb3gen2-vision-mezzanine.dtb |
+| QCS6490 IOT – Industrial kit | QCS6490 | RB3 Gen2 + Industrial Mezzanine | qcs6490-rb3gen2-industrial-mezzanine.dtb |
+| QCS9075 IOT (Lemans EVK i.e. rb8) | QCS9075, QCS9075v2 | Lemans EVK | lemans-evk.dtb |
+| QCS9100 QAM (Ride) | QCS9100, QCS9100v2 | Ride | qcs9100-ride.dtb |
+| QCS9100 QAM R2 (Ride R3) | QCS9100, QCS9100v2 | Ride R3 | qcs9100-ride-r3.dtb |
+| QCS8300 ADP (Ride) | QCS8300 | Ride (ADP) | qcs8300-ride.dtb |
+| QCS8275 IOT (Monaco EVK, rb4) | QCS8275 | Monaco EVK | monaco-evk.dtb |
+| QCS615 ADP (Ride) | QCS615, QCS615 v1.1 | Ride (ADP) | qcs615-ride.dtb |
+| SA8775P QAM (Ride) | SA8775P, SA8775Pv2 | Ride (QAM) | sa8775p-ride.dtb |
+| SA8775P QAM R2 (Ride R3) | SA8775P, SA8775Pv2 | Ride R3 (QAM R2) | sa8775p-ride-r3.dtb |
+| Hamoa IOT EVK | Hamoa, Hamoav2.1 | IOT EVK | hamoa-iot-evk.dtb |
+


### PR DESCRIPTION
Add list of supported platforms on Qualcomm Linux, referring to configuration under qcom-next-fitimage.its.