### PR TITLE
Separate out soc version and board revision as suffixes

### DIFF
--- a/qcom-fitimage.its
+++ b/qcom-fitimage.its
@@ -85,7 +85,7 @@
 			fdt = "fdt-lemans-evk.dtb";
 		};
 		conf-6 {
-			compatible = "qcom,qcs9075v2-iot";
+			compatible = "qcom,qcs9075-socv2.0-iot";
 			fdt = "fdt-lemans-evk.dtb";
 		};
 		conf-7 {
@@ -93,15 +93,15 @@
 			fdt = "fdt-qcs9100-ride.dtb";
 		};
 		conf-8 {
-			compatible = "qcom,qcs9100v2-qam";
+			compatible = "qcom,qcs9100-socv2.0-qam";
 			fdt = "fdt-qcs9100-ride.dtb";
 		};
 		conf-9 {
-			compatible = "qcom,qcs9100-qamr2";
+			compatible = "qcom,qcs9100-qam-r2.0";
 			fdt = "fdt-qcs9100-ride-r3.dtb";
 		};
 		conf-10 {
-			compatible = "qcom,qcs9100v2-qamr2";
+			compatible = "qcom,qcs9100-socv2.0-qam-r2.0";
 			fdt = "fdt-qcs9100-ride-r3.dtb";
 		};
 		conf-11 {
@@ -117,7 +117,7 @@
 			fdt = "fdt-qcs615-ride.dtb";
 		};
 		conf-14 {
-			compatible = "qcom,qcs615v1.1-adp";
+			compatible = "qcom,qcs615-socv1.1-adp";
 			fdt = "fdt-qcs615-ride.dtb";
 		};
 		conf-15 {
@@ -125,15 +125,15 @@
 			fdt = "fdt-sa8775p-ride.dtb";
 		};
 		conf-16 {
-			compatible = "qcom,sa8775pv2-qam";
+			compatible = "qcom,sa8775p-socv2.0-qam";
 			fdt = "fdt-sa8775p-ride.dtb";
 		};
 		conf-17 {
-			compatible = "qcom,sa8775p-qamr2";
+			compatible = "qcom,sa8775p-qam-r2.0";
 			fdt = "fdt-sa8775p-ride-r3.dtb";
 		};
 		conf-18 {
-			compatible = "qcom,sa8775pv2-qamr2";
+			compatible = "qcom,sa8775p-socv2.0-qam-r2.0";
 			fdt = "fdt-sa8775p-ride-r3.dtb";
 		};
 		conf-19 {
@@ -141,7 +141,7 @@
 			fdt = "fdt-hamoa-iot-evk.dtb";
 		};
 		conf-20 {
-			compatible = "qcom,hamoav2.1-evk";
+			compatible = "qcom,hamoa-socv2.1-evk";
 			fdt = "fdt-hamoa-iot-evk.dtb";
 		};
 	};

--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -13,68 +13,67 @@
 
 	soc {
 		hamoa {
-			msm-id = <0x000002c5 0x10>;
-		};
-
-		hamoav2.1 {
-			msm-id = <0x000002c5 0x21>;
+			msm-id = <0x000002c5>;
 		};
 
 		purwa {
-			msm-id = <0x000002c7 0x10>;
+			msm-id = <0x000002c7>;
 		};
 
 		qcm6490 {
-			msm-id = <0x000001f1 0x10>;
+			msm-id = <0x000001f1>;
 		};
 
 		qcs615 {
-			msm-id = <0x000002a8 0x10>;
-		};
-
-		qcs615v1.1 {
-			msm-id = <0x000002a8 0x11>;
+			msm-id = <0x000002a8>;
 		};
 
 		qcs5430 {
-			msm-id = <0x0000023f 0x10>;
+			msm-id = <0x0000023f>;
 		};
 
 		qcs6490 {
-			msm-id = <0x000001f2 0x10>;
+			msm-id = <0x000001f2>;
 		};
 
 		qcs8275 {
-			msm-id = <0x000002a3 0x10>;
+			msm-id = <0x000002a3>;
 		};
 
 		qcs8300 {
-			msm-id = <0x000002a2 0x10>;
+			msm-id = <0x000002a2>;
 		};
 
 		qcs9075 {
-			msm-id = <0x000002a4 0x10>;
-		};
-
-		qcs9075v2 {
-			msm-id = <0x000002a4 0x20>;
+			msm-id = <0x000002a4>;
 		};
 
 		qcs9100 {
-			msm-id = <0x0000029b 0x10>;
-		};
-
-		qcs9100v2 {
-			msm-id = <0x0000029b 0x20>;
+			msm-id = <0x0000029b>;
 		};
 
 		sa8775p {
-			msm-id = <0x00000216 0x10>;
+			msm-id = <0x00000216>;
+		};
+	};
+
+	socver {
+		socv1.0 {
+			socver-id = <0x10>;
 		};
 
-		sa8775pv2 {
-			msm-id = <0x00000216 0x20>;
+		socv1.1 {
+			socver-id = <0x11>;
 		};
+
+		socv2.0 {
+			socver-id = <0x20>;
+		};
+
+		socv2.1 {
+			socver-id = <0x21>;
+		};
+
 	};
 
 	soc-sku {
@@ -123,6 +122,25 @@
 		qrd {
 			board-id = <0x0000000b>;
 		};
+	};
+
+	boardrev {
+		r1.0 {
+			boardrev-id = <0x10>;
+		};
+
+		r1.1 {
+			boardrev-id = <0x11>;
+		};
+
+		r2.0 {
+			boardrev-id = <0x20>;
+		};
+
+		r2.1 {
+			boardrev-id = <0x21>;
+		};
+
 	};
 
 	board-subtype-peripheral-subtype {

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -117,7 +117,7 @@
 			fdt = "fdt-lemans-evk.dtb";
 		};
 		conf-6 {
-			compatible = "qcom,qcs9075v2-iot";
+			compatible = "qcom,qcs9075-socv2.0-iot";
 			fdt = "fdt-lemans-evk.dtb";
 		};
 		conf-7 {
@@ -125,15 +125,15 @@
 			fdt = "fdt-qcs9100-ride.dtb";
 		};
 		conf-8 {
-			compatible = "qcom,qcs9100v2-qam";
+			compatible = "qcom,qcs9100-socv2.0-qam";
 			fdt = "fdt-qcs9100-ride.dtb";
 		};
 		conf-9 {
-			compatible = "qcom,qcs9100-qamr2";
+			compatible = "qcom,qcs9100-qam-r2.0";
 			fdt = "fdt-qcs9100-ride-r3.dtb";
 		};
 		conf-10 {
-			compatible = "qcom,qcs9100v2-qamr2";
+			compatible = "qcom,qcs9100-socv2.0-qam-r2.0";
 			fdt = "fdt-qcs9100-ride-r3.dtb";
 		};
 		conf-11 {
@@ -149,7 +149,7 @@
 			fdt = "fdt-qcs615-ride.dtb";
 		};
 		conf-14 {
-			compatible = "qcom,qcs615v1.1-adp";
+			compatible = "qcom,qcs615-socv1.1-adp";
 			fdt = "fdt-qcs615-ride.dtb";
 		};
 		conf-15 {
@@ -157,15 +157,15 @@
 			fdt = "fdt-sa8775p-ride.dtb";
 		};
 		conf-16 {
-			compatible = "qcom,sa8775pv2-qam";
+			compatible = "qcom,sa8775p-socv2.0-qam";
 			fdt = "fdt-sa8775p-ride.dtb";
 		};
 		conf-17 {
-			compatible = "qcom,sa8775p-qamr2";
+			compatible = "qcom,sa8775p-qam-r2.0";
 			fdt = "fdt-sa8775p-ride-r3.dtb";
 		};
 		conf-18 {
-			compatible = "qcom,sa8775pv2-qamr2";
+			compatible = "qcom,sa8775p-socv2.0-qam-r2.0";
 			fdt = "fdt-sa8775p-ride-r3.dtb";
 		};
 		conf-19 {
@@ -173,7 +173,7 @@
 			fdt = "fdt-hamoa-iot-evk.dtb";
 		};
 		conf-20 {
-			compatible = "qcom,hamoav2.1-evk";
+			compatible = "qcom,hamoa-socv2.1-evk";
 			fdt = "fdt-hamoa-iot-evk.dtb";
 		};
 		conf-21 {
@@ -181,7 +181,7 @@
 			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-evk-camx.dtbo";
 		};
 		conf-22 {
-			compatible = "qcom,qcs9075v2-iot-camx";
+			compatible = "qcom,qcs9075-socv2.0-iot-camx";
 			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-evk-camx.dtbo";
 		};
 		conf-23 {
@@ -197,15 +197,15 @@
 			fdt = "fdt-sa8775p-ride.dtb", "fdt-sa8775p-ride-camx.dtbo";
 		};
 		conf-26 {
-			compatible = "qcom,sa8775pv2-qam-camx";
+			compatible = "qcom,sa8775p-socv2.0-qam-camx";
 			fdt = "fdt-sa8775p-ride.dtb", "fdt-sa8775p-ride-camx.dtbo";
 		};
 		conf-27 {
-			compatible = "qcom,sa8775p-qamr2-camx";
+			compatible = "qcom,sa8775p-qam-r2.0-camx";
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-sa8775p-ride-camx.dtbo";
 		};
 		conf-28 {
-			compatible = "qcom,sa8775pv2-qamr2-camx";
+			compatible = "qcom,sa8775p-socv2.0-qam-r2.0-camx";
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-sa8775p-ride-camx.dtbo";
 		};
 		conf-29 {
@@ -229,11 +229,11 @@
 			fdt = "fdt-talos-evk-lvds-auo,g133han01.dtb";
 		};
 		conf-34 {
-			compatible = "qcom,qcs615v1.1-iot";
+			compatible = "qcom,qcs615-socv1.1-iot";
 			fdt = "fdt-talos-evk.dtb";
 		};
 		conf-35 {
-			compatible = "qcom,qcs615v1.1-iot-subtype6";
+			compatible = "qcom,qcs615-socv1.1-iot-subtype6";
 			fdt = "fdt-talos-evk-lvds-auo,g133han01.dtb";
 		};
 		conf-36 {
@@ -241,7 +241,7 @@
 			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-37 {
-			compatible = "qcom,qcs9075v2-iot-el2kvm";
+			compatible = "qcom,qcs9075-socv2.0-iot-el2kvm";
 			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-38 {
@@ -249,15 +249,15 @@
 			fdt = "fdt-qcs9100-ride.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-39 {
-			compatible = "qcom,qcs9100v2-qam-el2kvm";
+			compatible = "qcom,qcs9100-socv2.0-qam-el2kvm";
 			fdt = "fdt-qcs9100-ride.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-40 {
-			compatible = "qcom,qcs9100-qamr2-el2kvm";
+			compatible = "qcom,qcs9100-qam-r2.0-el2kvm";
 			fdt = "fdt-qcs9100-ride-r3.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-41 {
-			compatible = "qcom,qcs9100v2-qamr2-el2kvm";
+			compatible = "qcom,qcs9100-socv2.0-qam-r2.0-el2kvm";
 			fdt = "fdt-qcs9100-ride-r3.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-42 {
@@ -265,7 +265,7 @@
 			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-evk-camx.dtbo", "fdt-lemans-el2.dtbo";
 		};
 		conf-43 {
-			compatible = "qcom,qcs9075v2-iot-camx-el2kvm";
+			compatible = "qcom,qcs9075-socv2.0-iot-camx-el2kvm";
 			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-evk-camx.dtbo", "fdt-lemans-el2.dtbo";
 		};
 		conf-44 {


### PR DESCRIPTION
For DT selection based on soc version and board revision, add support for socver and boardrev as separate nodes.