### PR TITLE
Update qcom-next-fitimage.its

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -273,35 +273,35 @@
 			fdt = "fdt-purwa-iot-evk.dtb";
 		};
 		conf-45 {
-			compatible = "qcom,sa8775p-qam";
+			compatible = "qcom,sa8775p-qam-el2kvm";
 			fdt = "fdt-sa8775p-ride.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-46 {
-			compatible = "qcom,sa8775p-socv2.0-qam";
+			compatible = "qcom,sa8775p-socv2.0-qam-el2kvm";
 			fdt = "fdt-sa8775p-ride.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-47 {
-			compatible = "qcom,sa8775p-qam-r2.0";
+			compatible = "qcom,sa8775p-qam-r2.0-el2kvm";
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-48 {
-			compatible = "qcom,sa8775p-socv2.0-qam-r2.0";
+			compatible = "qcom,sa8775p-socv2.0-qam-r2.0-el2kvm";
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-lemans-el2.dtbo";
 		};
 		conf-49 {
-			compatible = "qcom,sa8775p-qam-camx";
+			compatible = "qcom,sa8775p-qam-camx-el2kvm";
 			fdt = "fdt-sa8775p-ride.dtb", "fdt-sa8775p-ride-camx.dtbo", "fdt-lemans-el2.dtbo";
 		};
 		conf-50 {
-			compatible = "qcom,sa8775p-socv2.0-qam-camx";
+			compatible = "qcom,sa8775p-socv2.0-qam-camx-el2kvm";
 			fdt = "fdt-sa8775p-ride.dtb", "fdt-sa8775p-ride-camx.dtbo", "fdt-lemans-el2.dtbo";
 		};
 		conf-51 {
-			compatible = "qcom,sa8775p-qam-r2.0-camx";
+			compatible = "qcom,sa8775p-qam-r2.0-camx-el2kvm";
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-sa8775p-ride-camx.dtbo", "fdt-lemans-el2.dtbo";
 		};
 		conf-52 {
-			compatible = "qcom,sa8775p-socv2.0-qam-r2.0-camx";
+			compatible = "qcom,sa8775p-socv2.0-qam-r2.0-camx-el2kvm";
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-sa8775p-ride-camx.dtbo", "fdt-lemans-el2.dtbo";
 		};
 	};


### PR DESCRIPTION
Add lemans-el2.dtbo overlay support for sa8775p based automotive boards.