### PR TITLE
Update qcom-next-fitimage.its

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -213,7 +213,7 @@
 			fdt = "fdt-sa8775p-ride-r3.dtb", "fdt-sa8775p-ride-camx.dtbo";
 		};
 		conf-29 {
-			compatible = "qcom,qcs5430-iot";
+			compatible = "qcom,qcs5430-iot-subtype5";
 			fdt = "fdt-qcs6490-rb3gen2.dtb";
 		};
 		conf-30 {


### PR DESCRIPTION
Update QCS5430 Core Kit compatible string to use subtype5.