### PR TITLE
Update check-fitimage-metadata.sh

### DIFF
--- a/check-fitimage-metadata.sh
+++ b/check-fitimage-metadata.sh
@@ -33,7 +33,6 @@ META_FILE="${2:-qcom-metadata.dts}"
 # CONFIGURATION
 # -----------------------------------------------------------------------------
 BLACKLIST_SKIP_PATTERNS=("camx" "el2kvm")
-GLOBAL_FAILURE_OCCURRED=0
 
 if [[ ! -f "$ITS_FILE" ]]; then
     echo "fail FILE_NOT_FOUND $ITS_FILE" >&2


### PR DESCRIPTION
Certain compatible strings are used solely for applying overlays and are not defined in the hardware metadata. Add these to the script's blacklist to prevent false positive validation failures. 

Add check for existance of each FDT in the /images node in the same its file.

Update the purpose of the script and the flow logic.