### PR TITLE
Update qcom-metadata.dts for Glymur chip and CRD board

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -12,6 +12,10 @@
 	description = "Image with compressed metadata blob";
 
 	soc {
+		glymur {
+			msm-id = <0x00000296>;
+		};
+
 		hamoa {
 			msm-id = <0x000002c5>;
 		};
@@ -93,6 +97,10 @@
 
 		cdp {
 			board-id = <0x00000001>;
+		};
+
+		crd {
+			board-id = <0x00000028>;
 		};
 
 		evk {


### PR DESCRIPTION
Add support for Glymur chip msm-id and its CRD platform's board-id.