### PR TITLE
Update bit definition for board-subtype

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -195,19 +195,19 @@
 
 
 	board-subtype-storage-type {
-		emmc {
-			board-subtype = <0x00001000>;
+		ufs {
+			board-subtype = <0x00004000>;
 		};
 
 		nand {
-			board-subtype = <0x00002000>;
+			board-subtype = <0x00008000>;
 		};
 
 		sdcard {
-			board-subtype = <0x00003000>;
+			board-subtype = <0x0000C000>;
 		};
 
-		ufs {
+		emmc {
 			board-subtype = <0x00000000>;
 		};
 	};


### PR DESCRIPTION
Update in board-subtype bit definition.
Old:
0-7: board-subtype-peripheral-subtype
8-11 : board-subtype-memory-size
12-14: board-subtype-storage-type
15-31 : reserved
New:
0-7: board-subtype-peripheral-subtype
8-12 : board-subtype-memory-size
13: reserved
14-16: board-subtype-storage-type
17-31 : reserved

Updating EMMC, UFS bit definition based on how UEFI has implemented it. typedef enum {
    EMMC = 0,
    UFS = 1,
    NAND = 2,
    UNKNOWN,
} MemCardType;