### PR TITLE
Update qcom-next-fitimage.its to overlay fdt-lemans-camx-el2.dtbo

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -105,6 +105,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/talos-el2.dtbo");
 			type = "flat_dt";
 		};
+		fdt-lemans-camx-el2.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-camx-el2.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {


### PR DESCRIPTION
Update qcom-next-fitimage.its to overlay fdt-lemans-camx-el2.dtbo for Lemans
boards having support for camx-el2kvm.