### PR TITLE
qcom-next-fitimage.its: Add support for hamoa-iot-evk-camera-imx577.d…

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -109,6 +109,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-camx-el2.dtbo");
 			type = "flat_dt";
 		};
+		fdt-hamoa-iot-evk-camera-imx577.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-iot-evk-camera-imx577.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -162,7 +166,7 @@
 		};
 		conf-13 {
 			compatible = "qcom,hamoa-evk";
-			fdt = "fdt-hamoa-iot-evk.dtb";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-iot-evk-camera-imx577.dtbo";
 		};
 		conf-14 {
 			compatible = "qcom,qcs9075-iot-camx";


### PR DESCRIPTION
- Add fdt-hamoa-iot-evk-camera-imx577.dtbo to the images section
- Update conf-13 to include both fdt-hamoa-iot-evk.dtb and the new dtbo