### PR TITLE
Update qcom-next-fitimage.its for overlay of monaco-camx-el2.dtbo

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -113,6 +113,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-iot-evk-camera-imx577.dtbo");
 			type = "flat_dt";
 		};
+		fdt-monaco-camx-el2.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-camx-el2.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -254,11 +258,11 @@
 		};
 		conf-35 {
 			compatible = "qcom,qcs8275-iot-camx-el2kvm";
-			fdt = "fdt-monaco-evk.dtb", "fdt-monaco-evk-camx.dtbo", "fdt-monaco-el2.dtbo";
+			fdt = "fdt-monaco-evk.dtb", "fdt-monaco-evk-camx.dtbo", "fdt-monaco-el2.dtbo", "fdt-monaco-camx-el2.dtbo";
 		};
 		conf-36 {
 			compatible = "qcom,qcs8300-adp-camx-el2kvm";
-			fdt = "fdt-qcs8300-ride.dtb", "fdt-qcs8300-ride-camx.dtbo", "fdt-monaco-el2.dtbo";
+			fdt = "fdt-qcs8300-ride.dtb", "fdt-qcs8300-ride-camx.dtbo", "fdt-monaco-el2.dtbo", "fdt-monaco-camx-el2.dtbo";
 		};
 		conf-37 {
 			compatible = "qcom,glymur-crd";


### PR DESCRIPTION
Update qcom-next-fitimage.its to overlay monaco-camx-el2.dtbo for Monaco
boards which support camx and el2kvm.