### PR TITLE
Update qcom-next-fitimage.its for Hamoa EL2

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -117,6 +117,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-camx-el2.dtbo");
 			type = "flat_dt";
 		};
+		fdt-x1-el2.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/x1-el2.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -271,6 +275,10 @@
 		conf-38 {
 			compatible = "qcom,qcs615-adp-el2kvm";
 			fdt = "fdt-qcs615-ride.dtb", "fdt-talos-el2.dtbo";
+		};
+		conf-39 {
+			compatible = "qcom,hamoa-evk-el2kvm";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo";
 		};
 	};
 };


### PR DESCRIPTION
Add x1-el2.dtbo overlay support for hamoa-iot-evk board.