### PR TITLE
Update qcom-next-fitimage.its for Lemans and Monaco boards

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -121,6 +121,14 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/x1-el2.dtbo");
 			type = "flat_dt";
 		};
+		fdt-lemans-evk-ifp-mezzanine.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-evk-ifp-mezzanine.dtbo");
+			type = "flat_dt";
+		};
+		fdt-monaco-evk-ifp-mezzanine.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-evk-ifp-mezzanine.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -279,6 +287,14 @@
 		conf-39 {
 			compatible = "qcom,hamoa-evk-el2kvm";
 			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo";
+		};
+		conf-40 {
+			compatible = "qcom,qcs9075-iot-subtype1";
+			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-evk-ifp-mezzanine.dtbo";
+		};
+		conf-41 {
+			compatible = "qcom,qcs8275-iot-subtype3";
+			fdt = "fdt-monaco-evk.dtb", "fdt-monaco-evk-ifp-mezzanine.dtbo";
 		};
 	};
 };


### PR DESCRIPTION
Add support for Lemans RB8 Core Kit + Interface Plus Mezzanine and Monaco RB4 Core Kit + Interface Plus Mezzanine board support.