### PR TITLE
Update qcom-next-fitimage.its to add camera overlay for Hamoa EL2

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -294,7 +294,7 @@
 		};
 		conf-39 {
 			compatible = "qcom,hamoa-evk-el2kvm";
-			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-iot-evk-camera-imx577.dtbo", "fdt-x1-el2.dtbo";
 		};
 		conf-40 {
 			compatible = "qcom,qcs9075-iot-subtype1";


### PR DESCRIPTION
Hamoa board defaults to camera support via hamoa-iot-evk-camera-imx577.dtbo. Add the camera overlay to the hamoa-evk-el2kvm configuration (conf-39) to keep it consistent with the base hamoa-evk configuration (conf-13).