### PR TITLE
qcom-metadata: dts: add Shikra msm-id entries

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -59,6 +59,18 @@
 		sa8775p {
 			msm-id = <0x00000216>;
 		};
+
+		shikra-cqm {
+			msm-id = <0x000002f4>;
+		};
+
+		shikra-cqs {
+			msm-id = <0x000002f6>;
+		};
+
+		shikra-iqs {
+			msm-id = <0x000002f7>;
+		};
 	};
 
 	soc-sku {


### PR DESCRIPTION
Add metadata entries for shikra-cqm, shikra-cqs and shikra-iqs with their corresponding msm-id values.

This allows DTB selection to identify these Shikra variants during\nmetadata-based platform matching.