### PR TITLE
Add compatible support for qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo and board-subtype 

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -207,6 +207,10 @@
 		subtype10 {
 			board-subtype  = <0x0000000a>;
 		};
+
+		subtype13 {
+			board-subtype  = <0x0000000d>;
+		};
 	};
 
 

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -25,6 +25,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtb");
 			type = "flat_dt";
 		};
+		fdt-qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo");
+			type = "flat_dt";
+		};
 		fdt-lemans-evk.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-evk.dtb");
 			type = "flat_dt";
@@ -344,6 +348,10 @@
 		conf-47 {
 			compatible = "qcom,shikraiqs-itp";
 			fdt = "fdt-shikra-iqs-evk.dtb";
+		};
+		conf-48 {
+			compatible = "qcom,qcs6490-iot-subtype13";
+			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb", "fdt-qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo";
 		};
 	};
 };


### PR DESCRIPTION
Update qcom-metadata.dts and qcom-next-fitimage.its

Add compatible support for qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo
and board-subtype entry in qcom-metadata.dts
