### PR TITLE
qcom-next-fitimage.its: Add CamX DTBO support for Hamoa and Purwa EVK

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -137,6 +137,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-evk-camera-imx577.dtbo");
 			type = "flat_dt";
 		};
+		fdt-hamoa-evk-camx.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -307,6 +311,10 @@
 		conf-42 {
 			compatible = "qcom,purwa-evk-el2kvm";
 			fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo";
+		};
+		conf-43 {
+			compatible = "qcom,hamoa-evk-camx";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-evk-camx.dtbo";
 		};
 	};
 };

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -141,6 +141,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
 			type = "flat_dt";
 		};
+		fdt-purwa-evk-camx.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-evk-camx.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -315,6 +319,10 @@
 		conf-43 {
 			compatible = "qcom,hamoa-evk-camx";
 			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-evk-camx.dtbo";
+		};
+		conf-44 {
+			compatible = "qcom,purwa-evk-camx";
+			fdt = "fdt-purwa-iot-evk.dtb", "fdt-purwa-evk-camx.dtbo";
 		};
 	};
 };


### PR DESCRIPTION
This change includes:

- Add support for CamX DTBO overlays for Hamoa and Purwa EVK platforms.
- Update FIT image to include new DTBO entries for camera enablement.
- Introduce corresponding configurations to pair base DTB with CamX DTBO.
- Ensures proper integration of camera overlays for EVK bring-up.