### PR TITLE
Add Shikra CQM, CQS and IQS variant support

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -60,15 +60,15 @@
 			msm-id = <0x00000216>;
 		};
 
-		shikra-cqm {
+		shikracqm {
 			msm-id = <0x000002f4>;
 		};
 
-		shikra-cqs {
+		shikracqs {
 			msm-id = <0x000002f6>;
 		};
 
-		shikra-iqs {
+		shikraiqs {
 			msm-id = <0x000002f7>;
 		};
 	};

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -145,6 +145,15 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-evk-camx.dtbo");
 			type = "flat_dt";
 		};
+		fdt-shikra-cqm-evk.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/shikra-cqm-evk.dtb");
+		};
+		fdt-shikra-cqs-evk.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/shikra-cqs-evk.dtb");
+		};
+		fdt-shikra-iqs-evk.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/shikra-iqs-evk.dtb");
+		};
 	};
 
 	configurations {
@@ -323,6 +332,18 @@
 		conf-44 {
 			compatible = "qcom,purwa-evk-camx";
 			fdt = "fdt-purwa-iot-evk.dtb", "fdt-purwa-evk-camx.dtbo";
+		};
+		conf-45 {
+			compatible = "qcom,shikracqm-itp";
+			fdt = "fdt-shikra-cqm-evk.dtb";
+		};
+		conf-46 {
+			compatible = "qcom,shikracqs-itp";
+			fdt = "fdt-shikra-cqs-evk.dtb";
+		};
+		conf-47 {
+			compatible = "qcom,shikraiqs-itp";
+			fdt = "fdt-shikra-iqs-evk.dtb";
 		};
 	};
 };


### PR DESCRIPTION
Rename the existing shikra-cqm/cqs/iqs node names in qcom-metadata.dts. Add FDT image entries and FIT configurations for shikra-cqm-evk, shikra-cqs-evk and shikra-iqs-evk boards in qcom-next-fitimage.its.