### PR TITLE
Update qcom-next-fitimage.its: Update Hamoa & Purwa with camx overlay

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -154,6 +154,22 @@
 		fdt-shikra-iqs-evk.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/shikra-iqs-evk.dtb");
 		};
+		fdt-hamoa-camx-el2.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-camx-el2.dtbo");
+			type = "flat_dt";
+		};
+		fdt-hamoa-evk-camx.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
+			type = "flat_dt";
+		};
+		fdt-purwa-camx-el2.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-camx-el2.dtbo");
+			type = "flat_dt";
+		};
+		fdt-purwa-evk-camx.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-evk-camx.dtbo");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {
@@ -344,6 +360,14 @@
 		conf-47 {
 			compatible = "qcom,shikraiqs-itp";
 			fdt = "fdt-shikra-iqs-evk.dtb";
+		};
+		conf-48 {
+			compatible = "qcom,hamoa-evk-el2kvm-camx";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-hamoa-evk-camx.dtbo", "fdt-hamoa-camx-el2.dtbo";
+		};
+		conf-49 {
+			compatible = "qcom,purwa-evk-el2kvm";
+			fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-purwa-evk-camx.dtbo", "fdt-purwa-camx-el2.dtbo";
 		};
 	};
 };

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -361,9 +361,9 @@
 			compatible = "qcom,qcs6490-iot-subtype13";
 			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb", "fdt-qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo";
 		};
-    conf-49 {
+        conf-49 {
 			compatible = "qcom,hamoa-evk-camx-el2kvm";
-			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-camx-el2.dtbo", "fdt-x1-el2.dtbo", "fdt-hamoa-evk-camx.dtbo";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-evk-camx.dtbo", "fdt-x1-el2.dtbo", "fdt-hamoa-camx-el2.dtbo";
 		};
 		conf-50 {
 			compatible = "qcom,purwa-evk-camx-el2kvm";

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -366,7 +366,7 @@
 			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-hamoa-evk-camx.dtbo", "fdt-hamoa-camx-el2.dtbo";
 		};
 		conf-49 {
-			compatible = "qcom,purwa-evk-el2kvm";
+			compatible = "qcom,purwa-evk-el2kvm-camx";
 			fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-purwa-evk-camx.dtbo", "fdt-purwa-camx-el2.dtbo";
 		};
 	};

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -363,11 +363,11 @@
 		};
     conf-49 {
 			compatible = "qcom,hamoa-evk-camx-el2kvm";
-			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-hamoa-evk-camx.dtbo", "fdt-hamoa-camx-el2.dtbo";
+			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-hamoa-camx-el2.dtbo", "fdt-x1-el2.dtbo", "fdt-hamoa-evk-camx.dtbo";
 		};
 		conf-50 {
 			compatible = "qcom,purwa-evk-camx-el2kvm";
-			fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-purwa-evk-camx.dtbo", "fdt-purwa-camx-el2.dtbo";
+			fdt = "fdt-purwa-iot-evk.dtb", "fdt-purwa-evk-camx.dtbo", "fdt-x1-el2.dtbo", "fdt-purwa-camx-el2.dtbo";
 		};
 	};
 };

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -162,16 +162,8 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-camx-el2.dtbo");
 			type = "flat_dt";
 		};
-		fdt-hamoa-evk-camx.dtbo {
-			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
-			type = "flat_dt";
-		};
 		fdt-purwa-camx-el2.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-camx-el2.dtbo");
-			type = "flat_dt";
-		};
-		fdt-purwa-evk-camx.dtbo {
-			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-evk-camx.dtbo");
 			type = "flat_dt";
 		};
 	};
@@ -370,11 +362,11 @@
 			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb", "fdt-qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo";
 		};
     conf-49 {
-			compatible = "qcom,hamoa-evk-el2kvm-camx";
+			compatible = "qcom,hamoa-evk-camx-el2kvm";
 			fdt = "fdt-hamoa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-hamoa-evk-camx.dtbo", "fdt-hamoa-camx-el2.dtbo";
 		};
 		conf-50 {
-			compatible = "qcom,purwa-evk-el2kvm-camx";
+			compatible = "qcom,purwa-evk-camx-el2kvm";
 			fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo", "fdt-purwa-evk-camx.dtbo", "fdt-purwa-camx-el2.dtbo";
 		};
 	};


### PR DESCRIPTION
Add support for Hamoa/Purwa KVM enablement from the camera side by updating the FIT/DTB metadata flow to include the camx-el2 DTB/overlay for KVM boot scenarios. This enables the correct camera EL2 DTB to be packaged and selected during boot when virtualization is enabled, aligning with the TZ and camera-side changes discussed in the enablement thread.