### PR TITLE
Update qcom-metadata.dts: Update the Glymur SOC

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -13,7 +13,7 @@
 
 	soc {
 		glymur {
-			msm-id = <0x00000296>;
+			msm-id = <0x000002ba>;
 		};
 
 		hamoa {


### PR DESCRIPTION
The current SIP (System In Package) variant is NPOR for Glymur LNX, 
while the supported platform variant available is COB (Chip on Board) only. 
Since the board being used and validated corresponds to the COB SKU,
the APPS DT/configuration should align with the COB variant instead
of SIP. This change updates the Glymur SOC entries accordingly so 
that FIT image selection and platform metadata match the actual 
supported hardware configuration.