### PR TITLE
fitimage: use prebuilt EL2 DTBs in FIT configurations

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -29,6 +29,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-evk.dtb");
 			type = "flat_dt";
 		};
+		fdt-lemans-evk-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-evk-el2.dtb");
+			type = "flat_dt";
+		};
 		fdt-qcs9100-ride.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs9100-ride.dtb");
 			type = "flat_dt";
@@ -37,16 +41,36 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs9100-ride-r3.dtb");
 			type = "flat_dt";
 		};
+		fdt-qcs9100-ride-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs9100-ride-el2.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs9100-ride-r3-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs9100-ride-r3-el2.dtb");
+			type = "flat_dt";
+		};
 		fdt-qcs8300-ride.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs8300-ride.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs8300-ride-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs8300-ride-el2.dtb");
 			type = "flat_dt";
 		};
 		fdt-monaco-evk.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-evk.dtb");
 			type = "flat_dt";
 		};
+		fdt-monaco-evk-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-evk-el2.dtb");
+			type = "flat_dt";
+		};
 		fdt-qcs615-ride.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs615-ride.dtb");
+			type = "flat_dt";
+		};
+		fdt-qcs615-ride-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs615-ride-el2.dtb");
 			type = "flat_dt";
 		};
 		fdt-talos-evk.dtb {
@@ -69,8 +93,16 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-iot-evk.dtb");
 			type = "flat_dt";
 		};
+		fdt-hamoa-iot-evk-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-iot-evk-el2.dtb");
+			type = "flat_dt";
+		};
 		fdt-purwa-iot-evk.dtb {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-iot-evk.dtb");
+			type = "flat_dt";
+		};
+		fdt-purwa-iot-evk-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/purwa-iot-evk-el2.dtb");
 			type = "flat_dt";
 		};
 		fdt-glymur-crd.dtb {
@@ -81,8 +113,16 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-evk-camx.dtbo");
 			type = "flat_dt";
 		};
+		fdt-lemans-camx-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/lemans-camx-el2.dtb");
+			type = "flat_dt";
+		};
 		fdt-monaco-evk-camx.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-evk-camx.dtbo");
+			type = "flat_dt";
+		};
+		fdt-monaco-camx-el2.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/monaco-camx-el2.dtb");
 			type = "flat_dt";
 		};
 		fdt-qcs8300-ride-camx.dtbo {
@@ -255,15 +295,15 @@
 		};
 		conf-25 {
 			compatible = "qcom,qcs9100-qam-el2kvm";
-			fdt = "fdt-qcs9100-ride-r3.dtb", "fdt-lemans-el2.dtbo";
+			fdt = "fdt-qcs9100-ride-r3-el2.dtb";
 		};
 		conf-26 {
 			compatible = "qcom,qcs9100-qam-r1.0-el2kvm";
-			fdt = "fdt-qcs9100-ride.dtb", "fdt-lemans-el2.dtbo";
+			fdt = "fdt-qcs9100-ride-el2.dtb";
 		};
 		conf-27 {
 			compatible = "qcom,qcs9075-iot-camx-el2kvm";
-			fdt = "fdt-lemans-evk.dtb", "fdt-lemans-evk-camx.dtbo", "fdt-lemans-el2.dtbo", "fdt-lemans-camx-el2.dtbo";
+			fdt = "fdt-lemans-camx-el2.dtb";
 		};
 		conf-28 {
 			compatible = "qcom,purwa-evk";
@@ -287,7 +327,7 @@
 		};
 		conf-33 {
 			compatible = "qcom,qcs8300-adp-el2kvm";
-			fdt = "fdt-qcs8300-ride.dtb", "fdt-monaco-el2.dtbo";
+			fdt = "fdt-qcs8300-ride-el2.dtb";
 		};
 		conf-34 {
 			compatible = "qcom,qcs8275-iot-el2kvm";
@@ -295,7 +335,7 @@
 		};
 		conf-35 {
 			compatible = "qcom,qcs8275-iot-camx-el2kvm";
-			fdt = "fdt-monaco-evk.dtb", "fdt-monaco-evk-camx.dtbo", "fdt-monaco-el2.dtbo", "fdt-monaco-camx-el2.dtbo";
+			fdt = "fdt-monaco-camx-el2.dtb";
 		};
 		conf-36 {
 			compatible = "qcom,qcs8300-adp-camx-el2kvm";
@@ -307,7 +347,7 @@
 		};
 		conf-38 {
 			compatible = "qcom,qcs615-adp-el2kvm";
-			fdt = "fdt-qcs615-ride.dtb", "fdt-talos-el2.dtbo";
+			fdt = "fdt-qcs615-ride-el2.dtb";
 		};
 		conf-39 {
 			compatible = "qcom,hamoa-evk-el2kvm";
@@ -323,7 +363,7 @@
 		};
 		conf-42 {
 			compatible = "qcom,purwa-evk-el2kvm";
-			fdt = "fdt-purwa-iot-evk.dtb", "fdt-x1-el2.dtbo";
+			fdt = "fdt-purwa-iot-evk-el2.dtb";
 		};
 		conf-43 {
 			compatible = "qcom,hamoa-evk-camx";


### PR DESCRIPTION
Replace base DTB + EL2 DTBO combinations in FIT configurations with prebuilt EL2-specific DTBs.

EL2 reflects a different system configuration (e.g. hypervisor mode, memory layout and reserved regions), so it is more suitable to describe it using a complete DTB.

Using a DT overlay for this would imply modifying an existing system description, which is not appropriate for EL2 as it is not a hot-pluggable or optional hardware component.

Update the .its file to reference the EL2 DTBs directly across all relevant configurations.

this also inline with kernel [ maintainers comment](https://lore.kernel.org/all/0f045b88-94fc-46b5-8a49-8a53235fc8fc@kernel.org/) on [upstream request](https://lore.kernel.org/all/0f045b88-94fc-46b5-8a49-8a53235fc8fc@kernel.org/)
