### PR TITLE
scripts: add --soc and --board filtering to build-dtb-image.sh

### DIFF
--- a/build-dtb-image.sh
+++ b/build-dtb-image.sh
@@ -121,11 +121,14 @@ FIT_WORK_DIR=""        # Temporary staging directory for FIT build artefacts
 # ITS file used for FIT image generation — must exist in SCRIPT_DIR.
 DEFAULT_ITS_FILE="qcom-next-fitimage.its"
 
+SOC_FILTER=()          # Optional: one or more SOC names to filter configurations
+BOARD_FILTER=()        # Optional: one or more board names to further filter configurations
+
 # ---------------------------- Helper Functions -------------------------------
 
 usage() {
     cat <<EOF
-Usage: $0 (--kernel-deb <kernel.deb> | --dtb-src <path>) [--size <MB>] [--out <file>]
+Usage: $0 (--kernel-deb <kernel.deb> | --dtb-src <path>) [--soc <soc>...] [--board <board>...] [--size <MB>] [--out <file>]
 
   --kernel-deb, -kernel-deb  Path to Debian kernel package (.deb). DTBs located by probing:
                              1. <extract>/usr/lib/linux-image-*/        (Debian standard)
@@ -138,6 +141,22 @@ Usage: $0 (--kernel-deb <kernel.deb> | --dtb-src <path>) [--size <MB>] [--out <f
 
   --fit-image, -fit-image    Accepted for backward compatibility; FIT image
                              mode is the default and only mode (no-op).
+
+  --soc,       -soc          (Optional) One or more SOC names to filter configurations.
+                             Each must be a subnode under /soc in qcom-metadata.dts
+                             (e.g. qcs8275, qcs6490, sa8775p, hamoa, glymur).
+                             A conf is kept if its compatible contains ANY of the given
+                             names as a case-insensitive substring.
+                             Multiple values: --soc purwa sa8775p
+
+  --board,     -board        (Optional, requires --soc) One or more board names to
+                             further filter the --soc selection.
+                             Each must be a subnode under /board in qcom-metadata.dts
+                             (e.g. iot, evk, idp, qam, adp).
+                             A conf is kept if its compatible also contains ANY of the
+                             given board names as a substring.
+                             Multiple values: --board iot evk
+                             Error if no --soc-selected conf matches any board name.
 
   --size,      -size         FAT image size in MB (default: 4)
 
@@ -153,6 +172,130 @@ Notes:
   - Metadata files (ITS, DTS) are read from: ${SCRIPT_DIR}
 EOF
     exit 1
+}
+
+# Parse subnode names from a top-level node in qcom-metadata.dts.
+# Usage: get_dts_subnodes <dts_file> <node_name>
+# Prints one name per line.
+get_dts_subnodes() {
+    local dts_file="$1"
+    local node_name="$2"
+    awk -v node="${node_name}" '
+        $0 ~ "^\t" node "[[:space:]]*\\{" { in_node=1; next }
+        in_node && /^\t\t[a-z]/ {
+            match($0, /[a-z][a-z0-9-]*/); print substr($0, RSTART, RLENGTH)
+        }
+        in_node && /^\t\};/ { exit }
+    ' "${dts_file}"
+}
+
+# filter_its <its_file> <soc_filter> [board_filter]
+#
+# Reads the ITS file and emits a filtered images{} + configurations{} block.
+# Configurations are kept when their compatible string contains soc_filter
+# (case-insensitive substring).  If board_filter is also given, the compatible
+# must additionally contain board_filter as a substring (order-independent).
+# The fdt-qcom-metadata.dtb image entry is always retained.
+filter_its() {
+    local its_file="$1"
+    local soc="$2"
+    local board="${3:-}"
+
+    awk -v soc="${soc}" -v board="${board}" '
+BEGIN {
+    in_images   = 0; in_confs    = 0; in_block    = 0
+    brace_depth = 0; block_buf   = ""; block_label = ""
+    block_compat= ""; img_count  = 0; conf_count  = 0
+    n = split(tolower(soc),   soc_list,   " ")
+    m = split(tolower(board), board_list, " ")
+    seen_images = 0
+}
+/^[[:space:]]*images[[:space:]]*\{/ { seen_images = 1 }
+!seen_images { next }
+/^[[:space:]]*images[[:space:]]*\{/ && !in_block {
+    in_images = 1; in_confs = 0; next
+}
+/^[[:space:]]*configurations[[:space:]]*\{/ && !in_block {
+    in_confs = 1; in_images = 0; next
+}
+/^\t\};$/ && !in_block { in_images = 0; in_confs = 0; next }
+in_images && !in_block && /^\t\t[^ ]/ {
+    match($0, /[^\t ]+/)
+    block_label = substr($0, RSTART, RLENGTH)
+    in_block = 1; brace_depth = 1; block_buf = $0 "\n"; next
+}
+in_images && in_block {
+    block_buf = block_buf $0 "\n"
+    n = split($0, chars, "")
+    for (i = 1; i <= n; i++) {
+        if (chars[i] == "{") brace_depth++
+        if (chars[i] == "}") brace_depth--
+    }
+    if (brace_depth == 0) {
+        img_blocks[block_label] = block_buf; img_count++
+        in_block = 0; block_buf = ""; block_label = ""
+    }
+    next
+}
+in_confs && !in_block && /^\t\tconf-[0-9]/ {
+    in_block = 1; brace_depth = 1; block_buf = $0 "\n"; block_compat = ""; next
+}
+in_confs && in_block {
+    block_buf = block_buf $0 "\n"
+    if ($0 ~ /compatible[[:space:]]*=/) {
+        match($0, /"[^"]+"/)
+        block_compat = substr($0, RSTART+1, RLENGTH-2)
+    }
+    n = split($0, chars, "")
+    for (i = 1; i <= n; i++) {
+        if (chars[i] == "{") brace_depth++
+        if (chars[i] == "}") brace_depth--
+    }
+    if (brace_depth == 0) {
+        compat_lower = tolower(block_compat)
+        soc_match = 0
+        for (si in soc_list)   if (index(compat_lower, soc_list[si])   > 0) soc_match = 1
+        board_match = (m == 0)
+        for (bi in board_list) if (index(compat_lower, board_list[bi]) > 0) board_match = 1
+        if (soc_match && board_match) {
+            conf_count++
+            conf_blocks[conf_count] = block_buf
+            tmp = block_buf
+            while (match(tmp, /"fdt-[^"]+"/) > 0) {
+                needed_fdts[substr(tmp, RSTART+1, RLENGTH-2)] = 1
+                tmp = substr(tmp, RSTART + RLENGTH)
+            }
+        }
+        in_block = 0; block_buf = ""; block_compat = ""
+    }
+    next
+}
+END {
+    if (conf_count == 0) {
+        if (m > 0)
+            print "[ERROR] No configurations matched SOC=\"" soc "\" BOARD=\"" board "\"" > "/dev/stderr"
+        else
+            print "[ERROR] No configurations matched SOC filter: " soc > "/dev/stderr"
+        exit 1
+    }
+    print "\timages {"
+    if ("fdt-qcom-metadata.dtb" in img_blocks)
+        printf "%s", img_blocks["fdt-qcom-metadata.dtb"]
+    for (lbl in img_blocks) {
+        if (lbl == "fdt-qcom-metadata.dtb") continue
+        if (lbl in needed_fdts) printf "%s", img_blocks[lbl]
+    }
+    print "\t};"
+    print ""
+    print "\tconfigurations {"
+    for (i = 1; i <= conf_count; i++) {
+        blk = conf_blocks[i]
+        sub(/conf-[0-9]+[[:space:]]*\{/, "conf-" i " {", blk)
+        printf "%s", blk
+    }
+    print "\t};"
+}
+' "${its_file}"
 }
 
 require_cmd() {
@@ -207,6 +350,18 @@ while [[ $# -gt 0 ]]; do
             PRUNE=1
             shift 1
             ;;
+        -soc|--soc)
+            shift
+            while [[ $# -gt 0 && "$1" != --* && "$1" != -* ]]; do
+                SOC_FILTER+=("$1"); shift
+            done
+            ;;
+        -board|--board)
+            shift
+            while [[ $# -gt 0 && "$1" != --* && "$1" != -* ]]; do
+                BOARD_FILTER+=("$1"); shift
+            done
+            ;;
         -h|--help)
             usage
             ;;
@@ -232,6 +387,34 @@ fi
 if ! [[ "${DTB_BIN_SIZE}" =~ ^[0-9]+$ ]] || (( DTB_BIN_SIZE <= 0 )); then
     echo "[ERROR] --size must be a positive integer (MB), got '${DTB_BIN_SIZE}'." >&2
     exit 1
+fi
+
+# Validate --soc and --board against qcom-metadata.dts subnodes
+if [[ ${#BOARD_FILTER[@]} -gt 0 && ${#SOC_FILTER[@]} -eq 0 ]]; then
+    echo "[ERROR] --board requires --soc to be specified as well." >&2
+    exit 1
+fi
+
+if [[ ${#SOC_FILTER[@]} -gt 0 ]]; then
+    valid_socs=$(get_dts_subnodes "${SCRIPT_DIR}/qcom-metadata.dts" "soc")
+    for _soc in "${SOC_FILTER[@]}"; do
+        if ! echo "${valid_socs}" | grep -qx "${_soc}"; then
+            echo "[ERROR] Invalid --soc '${_soc}'. Valid SOC names (from /soc in qcom-metadata.dts):" >&2
+            echo "${valid_socs}" | sed 's/^/        /' >&2
+            exit 1
+        fi
+    done
+fi
+
+if [[ ${#BOARD_FILTER[@]} -gt 0 ]]; then
+    valid_boards=$(get_dts_subnodes "${SCRIPT_DIR}/qcom-metadata.dts" "board")
+    for _board in "${BOARD_FILTER[@]}"; do
+        if ! echo "${valid_boards}" | grep -qx "${_board}"; then
+            echo "[ERROR] Invalid --board '${_board}'. Valid board names (from /board in qcom-metadata.dts):" >&2
+            echo "${valid_boards}" | sed 's/^/        /' >&2
+            exit 1
+        fi
+    done
 fi
 
 # Validate that required metadata files are present in the repository
@@ -368,9 +551,34 @@ echo "[INFO] qcom-metadata.dtb generated:"
 ls -lh "${FIT_STAGE}/qcom-metadata.dtb"
 
 # -----------------------------------------------------------------------
-# Step 3. Copy ITS file into the staging directory
+# Step 3. Copy or filter ITS file into the staging directory
 # -----------------------------------------------------------------------
-cp "${SCRIPT_DIR}/${DEFAULT_ITS_FILE}" "${FIT_STAGE}/${DEFAULT_ITS_FILE}"
+if [[ ${#SOC_FILTER[@]} -gt 0 ]]; then
+    _soc_str="${SOC_FILTER[*]}"
+    _board_str="${BOARD_FILTER[*]+"${BOARD_FILTER[*]}"}"
+    _filter_desc="SOC='${_soc_str}'"
+    [[ -n "${_board_str}" ]] && _filter_desc+=" BOARD='${_board_str}'"
+    echo "[INFO] Generating filtered ITS (${_filter_desc})..."
+
+    header_lines=$(awk '/^[[:space:]]*images[[:space:]]*\{/{print NR-1; exit}'         "${SCRIPT_DIR}/${DEFAULT_ITS_FILE}")
+    head -n "${header_lines}" "${SCRIPT_DIR}/${DEFAULT_ITS_FILE}"         > "${FIT_STAGE}/${DEFAULT_ITS_FILE}"
+
+    filter_its "${SCRIPT_DIR}/${DEFAULT_ITS_FILE}" "${_soc_str}" "${_board_str}"         >> "${FIT_STAGE}/${DEFAULT_ITS_FILE}"
+
+    echo "};" >> "${FIT_STAGE}/${DEFAULT_ITS_FILE}"
+
+    echo "[INFO] Selected configurations:"
+    awk '
+/^\t\tconf-[0-9]+ \{/{in_conf=1}
+in_conf && /compatible/{match($0,/"[^"]+"/); print "        " substr($0,RSTART+1,RLENGTH-2)}
+in_conf && /^\t\t\};/{in_conf=0}
+' "${FIT_STAGE}/${DEFAULT_ITS_FILE}"
+
+    unset _soc_str _board_str _filter_desc
+else
+    echo "[INFO] Using full ITS (all configurations)."
+    cp "${SCRIPT_DIR}/${DEFAULT_ITS_FILE}" "${FIT_STAGE}/${DEFAULT_ITS_FILE}"
+fi
 
 # -----------------------------------------------------------------------
 # Step 3b. Prune ITS (only when --prune is given)

--- a/build-qcom-dtb-image.sh
+++ b/build-qcom-dtb-image.sh
@@ -11,6 +11,7 @@
 #   ./build-qcom-dtb-image.sh [--kernel-repo <url>] [--kernel-branch <branch>]
 #                             [--kernel-dir <path>] [--kobj <path>]
 #                             [--out <file>] [--size <MB>]
+#                             [--soc <soc-name>...] [--board <board-name>...]
 
 set -euo pipefail
 
@@ -22,6 +23,8 @@ KERNEL_DIR="kernel-src"
 KOBJ="kobj"
 DTB_BIN="dtb.bin"
 DTB_BIN_SIZE=4
+SOC_FILTER=()
+BOARD_FILTER=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -31,6 +34,18 @@ while [[ $# -gt 0 ]]; do
         --kobj)          KOBJ="$2";          shift 2 ;;
         --out)           DTB_BIN="$2";       shift 2 ;;
         --size)          DTB_BIN_SIZE="$2";  shift 2 ;;
+        --soc)
+            shift
+            while [[ $# -gt 0 && "$1" != --* && "$1" != -* ]]; do
+                SOC_FILTER+=("$1"); shift
+            done
+            ;;
+        --board)
+            shift
+            while [[ $# -gt 0 && "$1" != --* && "$1" != -* ]]; do
+                BOARD_FILTER+=("$1"); shift
+            done
+            ;;
         *) echo "[ERROR] Unknown option: $1" >&2; exit 1 ;;
     esac
 done
@@ -58,10 +73,15 @@ make -C "${KERNEL_DIR}" ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- O="../${KOBJ
 DTB_SRC="${KOBJ}/arch/arm64/boot/dts/qcom"
 echo "[INFO] Built $(find "${DTB_SRC}" \( -name '*.dtb' -o -name '*.dtbo' \) | wc -l) qcom DTB(s)"
 
-# Step 4: Build FAT DTB image
+# Step 4: Build FAT DTB image (pass --soc / --board when given)
+_extra_args=()
+for _s in "${SOC_FILTER[@]+"${SOC_FILTER[@]}"}";   do _extra_args+=(--soc   "$_s"); done
+for _b in "${BOARD_FILTER[@]+"${BOARD_FILTER[@]}"}"; do _extra_args+=(--board "$_b"); done
+
 "${SCRIPT_DIR}/build-dtb-image.sh" \
     --dtb-src "${DTB_SRC}" \
     --out "${DTB_BIN}" \
-    --size "${DTB_BIN_SIZE}"
+    --size "${DTB_BIN_SIZE}" \
+    "${_extra_args[@]}"
 
 echo "[INFO] Done: $(ls -lh "${DTB_BIN}" | awk '{print $5, $9}')"


### PR DESCRIPTION
Add optional --soc and --board arguments to build-dtb-image.sh and build-qcom-dtb-image.sh to allow building a filtered FIT DTB image containing only the configurations relevant to a specific SOC and/or board, instead of always building the full image.

--soc <name>   filters conf entries whose compatible string contains
               <name> as a case-insensitive substring. The name must
               be a subnode of /soc in qcom-metadata.dts (e.g. hamoa,
               qcs8275, sa8775p, qcs6490).

--board <name> further narrows the --soc selection to conf entries
               whose compatible also contains <name> as a substring.
               The name must be a subnode of /board in qcom-metadata.dts
               (e.g. iot, evk, qam, adp, idp). Requires --soc.
               Errors out if no --soc-selected conf matches the board.

Both options are optional; omitting them preserves the existing behaviour (full image, all configurations).

Examples:
  # All configs for hamoa
  ./build-dtb-image.sh --soc hamoa --dtb-src arch/arm64/boot/dts/qcom

  # Only qcs8275 iot configs
  ./build-dtb-image.sh --soc qcs8275 --board iot --dtb-src <path>

  # sa8775p qam configs, kernel cloned automatically
  ./build-qcom-dtb-image.sh --soc sa8775p --board qam --out sa8775p-qam.bin

Validation is done at runtime by parsing subnode names directly from qcom-metadata.dts, so the valid name lists stay in sync with the DTS automatically.