### PR TITLE
qcom-next-fitimage.its: fix indentation

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -230,10 +230,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/glymur-crd-camx.dtbo");
 			type = "flat_dt";
 		};
-    fdt-kodiak-el2.dtbo {
+		fdt-kodiak-el2.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/kodiak-el2.dtbo");
-     	type = "flat_dt";
-    };
+     		type = "flat_dt";
+    	};
 	};
 
 	configurations {
@@ -465,7 +465,7 @@
 			compatible = "qcom,glymur-crd-camx";
 			fdt = "fdt-glymur-crd.dtb", "fdt-glymur-crd-camx.dtbo";
 		};
-    conf-58 {
+		conf-58 {
 			compatible = "qcom,qcs6490-iot-el2kvm";
 			fdt = "fdt-qcs6490-rb3gen2.dtb", "fdt-kodiak-el2.dtbo";
 		};

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -184,7 +184,7 @@
 		fdt-hamoa-staging.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-staging.dtbo");
 			type = "flat_dt";
-		}; 
+		};
 		fdt-hamoa-evk-camx.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
 			type = "flat_dt";


### PR DESCRIPTION
  The fdt-kodiak-el2.dtbo image block and conf-58 configuration entry  were indented with spaces instead of tabs, inconsistent with the rest of the file. This caused the --prune awk logic to miss these blocks when matching against tab-anchored patterns, resulting in the image entry being printed verbatim to the pruned ITS even when the file was absent, and conf-58 being passed through unconditionally regardless of whether its referenced DTBs existed.

The space in the end of fdt-hamoa-staging-dtbo block cause the prune option did not work normally. remove the space to keep staging dtbo in the remain ITS image entries.