### PR TITLE
qcom-next-fitimage: remove the space in hamoa staging dtbo

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -184,7 +184,7 @@
 		fdt-hamoa-staging.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-staging.dtbo");
 			type = "flat_dt";
-		}; 
+		};
 		fdt-hamoa-evk-camx.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/hamoa-evk-camx.dtbo");
 			type = "flat_dt";


### PR DESCRIPTION
The space at the end of the `fdt-hamoa-staging-dtbo` block causes the
prune option to not work normally. Remove the trailing space to keep
staging dtbo in the remaining ITS image entries.
