### PR TITLE
Revert "Merge pull request #124 from shashim-quic/nord"

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -24,16 +24,8 @@
 			msm-id = <0x00000294>;
 		};
 
-		nord {
-			msm-id = <0x00000288>;
-		};
-
 		purwa {
 			msm-id = <0x000002c7>;
-		};
-
-		qam8x97p {
-			msm-id = <0x000002b2>;
 		};
 
 		qcm6490 {

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -233,11 +233,7 @@
 		fdt-kodiak-el2.dtbo {
 			data = /incbin/("./arch/arm64/boot/dts/qcom/kodiak-el2.dtbo");
      		type = "flat_dt";
-		};
-		fdt-sa8797p-ride.dtb {
-			data = /incbin/("./arch/arm64/boot/dts/qcom/sa8797p-ride.dtb");
-			type = "flat_dt";
-		};
+    	};
 	};
 
 	configurations {
@@ -480,14 +476,6 @@
 		conf-60 {
 			compatible = "qcom,qcs6490-iot-subtype9-el2kvm";
 			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb", "fdt-kodiak-el2.dtbo";
-		};
-		conf-61 {
-			compatible = "qcom,qam8x97p-qam";
-			fdt = "fdt-sa8797p-ride.dtb";
-		};
-		conf-62 {
-			compatible = "qcom,nord-qam";
-			fdt = "fdt-sa8797p-ride.dtb";
 		};
 	};
 };


### PR DESCRIPTION
This reverts commit f9d14a10e43aa40e935d57c4eb9f4e81a98f6f54, reversing changes made to f14303506b0bbc649e03204358880c46fc305ddb.

Reason: sa8797p-ride.dts is not yet available in qcom-next; adding the ITS entry and metadata before the DTB exists in the kernel tree causes the FIT image build to fail. It will be added once sa8797p-ride.dts will be available.