### PR TITLE
ci: trigger Build DTB Image workflow on pull_request events

### DIFF
--- a/.github/workflows/build-dtb-image.yml
+++ b/.github/workflows/build-dtb-image.yml
@@ -3,6 +3,7 @@ name: Build DTB Image
 on:
   push:
     branches: [ main ]
+  pull_request:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
  This change adds a pull_request trigger so the workflow also runs automatically whenever a PR is opened, updated, or synchronized against main. This ensures:

  - DTB image build is validated before a PR is merged, catching regressions early.
  - Contributors get immediate CI feedback on their changes without waiting for a maintainer to trigger it manually.
  - The existing push: branches: [main] and workflow_dispatch triggers are unchanged — no existing behaviour is affected.
