### PR TITLE
fitimage: rename rb3gen2 industrial mezzanine UART BT overlay

### DIFF
--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -25,8 +25,8 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine.dtb");
 			type = "flat_dt";
 		};
-		fdt-qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo {
-			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo");
+		fdt-qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtbo {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtbo");
 			type = "flat_dt";
 		};
 		fdt-lemans-evk.dtb {
@@ -427,7 +427,7 @@
 		};
 		conf-48 {
 			compatible = "qcom,qcs6490-iot-subtype13";
-			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb", "fdt-qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo";
+			fdt = "fdt-qcs6490-rb3gen2-industrial-mezzanine.dtb", "fdt-qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtbo";
 		};
 		conf-49 {
 			compatible = "qcom,hamoa-evk-camx-el2kvm";


### PR DESCRIPTION
fit-dtb-compatible: use renamed rb3gen2 industrial mezzanine BT UART overlay

Update the FIT image metadata to use the renamed RB3 Gen2 industrial mezzanine subtype 13 overlay.

The kernel overlay was renamed from the old M.2 Cologne name to one that describes the board-level routing change: Bluetooth over UART on the reworked industrial mezzanine board.

Replace qcs6490-rb3gen2-industrial-mezzanine-m2-cologne.dtbo with qcs6490-rb3gen2-industrial-mezzanine-bt-uart.dtbo in the FIT image entry and subtype 13 configuration.