### PR TITLE
Add FIT support for Mahua CRD board

### DIFF
--- a/qcom-metadata.dts
+++ b/qcom-metadata.dts
@@ -24,6 +24,10 @@
 			msm-id = <0x00000294>;
 		};
 
+		mahua {
+			msm-id = <0x000002b5>;
+		};
+
 		purwa {
 			msm-id = <0x000002c7>;
 		};

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -521,5 +521,10 @@
 			compatible = "qcom,qcs5430-iot-camx";
 			fdt = "fdt-qcs6490-rb3gen2.dtb", "fdt-qcs5430-fps-camx.dtbo";
 		};
+		conf-69 {
+			compatible = "qcom,mahua-crd";
+			fdt = "fdt-mahua-crd.dtb";
+		};
+
 	};
 };

--- a/qcom-next-fitimage.its
+++ b/qcom-next-fitimage.its
@@ -246,6 +246,10 @@
 			data = /incbin/("./arch/arm64/boot/dts/qcom/glymur-staging.dtbo");
 			type = "flat_dt";
 		};
+		fdt-mahua-crd.dtb {
+			data = /incbin/("./arch/arm64/boot/dts/qcom/mahua-crd.dtb");
+			type = "flat_dt";
+		};
 	};
 
 	configurations {


### PR DESCRIPTION
- Add msm-id 0x2b5 for mahua in qcom-metadata.dts
- Add conf-69 for qcom,mahua-crd in qcom-next-fitimage.its